### PR TITLE
Typo in info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -2,6 +2,6 @@
     "$schema": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog_repo.schema.json",
     "author": ["Predeactor"],
     "description": "Cog for administrating a Red Discord Bot instance. Get your own instance at https://discord.red",
-    "install_msg": "Thank for installing my cogs.\nPlease not that this cog will remaing unapproved by Cog Creators as long as I want to. I also do not provide support if I do not want to. It's all up to me.",
+    "install_msg": "Thank for installing my cogs.\nPlease not that this cog will remain unapproved by Cog Creators as long as I want to. I also do not provide support if I do not want to. It's all up to me.",
     "short": "Cog for administrating a Red Discord Bot instance."
 }


### PR DESCRIPTION
I have removed your typo on the word "remain", and changed it to the correct spelling.